### PR TITLE
Implement faster matrix assembly

### DIFF
--- a/include/multigrid/reduce_and_assemble.h
+++ b/include/multigrid/reduce_and_assemble.h
@@ -284,10 +284,11 @@ partially_assemble_ablock(const dealii::DoFHandler<dim, spacedim> &dof_handler,
       constexpr unsigned int n_lanes = dealii::VectorizedArray<double>::size();
       for (unsigned int k = 0; k < dof_indices.size(); k += n_lanes)
         {
+          dealii::VectorizedArray<double> *dof_values = evaluator.begin_dof_values();
           for (unsigned int i = 0; i < evaluator.dofs_per_cell; ++i)
-            evaluator.begin_dof_values()[i] = {};
+            dof_values[i] = {};
           for (unsigned int j = k; j < dof_indices.size() && j - k < n_lanes; ++j)
-            evaluator.begin_dof_values()[dof_indices[j]][j - k] = 1.0;
+            dof_values[dof_indices[j]][j - k] = 1.0;
 
           evaluator.evaluate(dealii::EvaluationFlags::gradients);
           for (unsigned int q = 0; q < evaluator.n_q_points; ++q)
@@ -298,7 +299,7 @@ partially_assemble_ablock(const dealii::DoFHandler<dim, spacedim> &dof_handler,
 
           for (unsigned int j = k; j < dof_indices.size() && j - k < n_lanes; ++j)
             for (unsigned int i = 0; i < dof_indices.size(); ++i)
-              cell_matrix(i, j) = evaluator.begin_dof_values()[dof_indices[i]][j - k];
+              cell_matrix(i, j) = dof_values[dof_indices[i]][j - k];
         }
 
       constraints_reduced.distribute_local_to_global(cell_matrix,


### PR DESCRIPTION
Here is an attempt that should make the matrix assembly on the patch considerably faster. Instead of trying to use the matrix-free infrastructure directly (that needs to filter out different cases), I opted to choose the entry point to `FEEvaluation` with the same ingredients as `FEValues`, i.e., reinit via `cell_iterator`. This code is wasteful because it computes the full column, rather than only the ones selected for the patch. Nonetheless, the underlying complexities and data structures are such that on my machine, this brings the assembly cost down to the point where inserting the entries into the matrix takes more than 70% of the time in this function.